### PR TITLE
Update to only allow 1 level of nesting instead of 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 ***
 
 ##### Avoid deep nesting
-> Try not to nest more than 3 levels deep.
+> Try not to nest more than 1 level deep.
 
 *Examples*: [nesting](src/nesting.erl)
 
 *Reasoning*: Nested levels indicate deep logic in a function, too many decisions taken or things done in a single function. This hinders not only readability, but also maintainability (making changes) and debugging, and writing unit tests.
+See also: [More, smaller functions over case expressions](#more-smaller-functions-over-case-expressions).
 
 ***
 ##### More, smaller functions over case expressions

--- a/src/nesting.erl
+++ b/src/nesting.erl
@@ -26,11 +26,14 @@ good() ->
     calls ->
       other:functions();
     that ->
-      try do:the(internal, parts) of
-        what ->
-          was:done(in)
-      catch
-        _:the ->
-          previous:example()
-      end
+      internal_work()
   end.
+
+  internal_work() ->
+    try do:the(internal, parts) of
+      what ->
+        was:done(in)
+    catch
+      _:the ->
+        previous:example()
+    end


### PR DESCRIPTION
We prefer no more than 1 level of nesting in functions. Update guideline and examples to reflect this.

Before merging this PR, go over this checklist:
- [X] The issue was approved by a considerable number of votes
- [X] The rule is listed in the table of contents
- [X] The rule text respects the structure:
    - [X] Title
    - [X] Short Description
    - [X] Examples
    - [X] Reasoning
- [X] It provides links to examples in code for
    - [X] good scenarios
    - [X] bad scenarios

