### PR TITLE
Switch from 80 to 100 chars for our length limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Table of Contents:
     * [Spaces over tabs](#spaces-over-tabs)
     * [Use your spacebar](#use-your-spacebar)
     * [No Trailing Whitespace](#no-trailing-whitespace)
-    * [80 column per line](#80-column-per-line)
+    * [100 column per line](#100-column-per-line)
     * [Maintain existing style](#maintain-existing-style)
     * [Avoid deep nesting](#avoid-deep-nesting)
     * [More, smaller functions over case expressions](#more-smaller-functions-over-case-expressions)
@@ -119,12 +119,13 @@ And you can check all of our open-source projects at [inaka.github.io](http://in
 Erlang syntax is horrible amirite? So you might as well make the best of it, right? _Right_?
 
 ***
-##### 80 column per line
-> Stick to 80 chars per line, some of us still have to use vi sometimes, specially when editing code via ssh. Also, it allows showing more than one file simultaneously on a wide screen or laptop monitor.
+##### 100 column per line
+> Stick to 100 chars per line, maximum.
 
 *Examples*: [col_width](src/col_width.erl)
 
-*Reasoning*: Not having to scroll horizontally while editing is a HUGE gain. Also, in wider screens you can open two files: one beside the other.
+*Reasoning*: Excessively long lines are a pain to deal with: you either have to scroll horizontally while editing, or live with ugly line wrapping at arbitrary points.
+The 100 character limit also keeps lines short enough that you can comfortably work with two source files side by side on a typical laptop screen, or three on a 1080p display.
 
 ***
 ##### Maintain existing style

--- a/src/col_width.erl
+++ b/src/col_width.erl
@@ -8,7 +8,7 @@
 bad([#rec{field1 = FF1, field2 = FF2, field3 = FF3}, #rec{field1 = BF1, field2 = BF2, field3 = BF3} | Rest], Arg2) ->
   other_module:bad(FF1, FF2, FF3, BF1, BF2, BF3, bad(Rest, Arg2)).
 
-%% @doc good (< 80 chars)
+%% @doc good (< 100 chars)
 good([Foo, Bar | Rest], Arg2) ->
   #rec{field1 = FF1, field2 = FF2, field3 = FF3} = Foo,
   #rec{field1 = BF1, field2 = BF2, field3 = BF3} = Bar,


### PR DESCRIPTION
80 characters is an excessively short limit for today's large, high-resolution displays. The 80-char pseudo-standard is a holdover from punchcards and 80x24 dumb terminals; I sincerely hope nobody is using either of those technologies at Basho to write Erlang code ;-)

Having a limit is still a good thing. 100 chars seems like a reasonable compromise, in that it still allows for comfortable side-by-side editing of multiple files, even on smaller laptop screens. Much of our existing code conforms to a 100 char limit as well.